### PR TITLE
Support for the Logitech R400 Wireless Presentation Remote (+ a small refactor)

### DIFF
--- a/weenote.js
+++ b/weenote.js
@@ -48,8 +48,15 @@ onload = function() {
     fit(next)
   }()
 
+  const FORWARD = 1
+  const BACKWARD = -1
+  const keyToSlideDirection = {
+    "ArrowRight": FORWARD, "ArrowLeft": BACKWARD,
+    "PageDown": FORWARD, "PageUp": BACKWARD
+  }
+
   document.onkeydown = function(e) {
-    var i = slide + {"ArrowRight": 1, "ArrowLeft": -1}[e.key]
+    var i = slide + keyToSlideDirection[e.key]
 
     if (i in slides) location.hash = i
   }

--- a/weenote.js
+++ b/weenote.js
@@ -49,7 +49,7 @@ onload = function() {
   }()
 
   document.onkeydown = function(e) {
-    var i = slide + {39: 1, 37: -1}[e.which]
+    var i = slide + {"ArrowRight": 1, "ArrowLeft": -1}[e.key]
 
     if (i in slides) location.hash = i
   }


### PR DESCRIPTION
I am currently working on a presentation using weenote and found that it wasn't compatible with a particular presentation remote I was using.

This PR adds support for the Logitech R400 Wireless Presentation Remote which uses the `PageDown` and `PageUp` keys to control presentation slides.

I've also included a minor refactor to replace the now deprecated `KeyboardEvent.which` property with `KeyboardEvent.key`.