### PR TITLE
Use transform to fit slide into browser window

### DIFF
--- a/weenote.js
+++ b/weenote.js
@@ -5,26 +5,34 @@ onload = function() {
 
   function fit(el) {
     var style = el.style
-    var i = 1000
-    var top
-    var left
-
-    style.display  = "inline"
-    style.fontSize = i + "px"
+    var font = 200
+    var margin = 15;
+    var width, height;
+    var scalex, scaley, scale;
+    
+    style.fontSize = font + "px"
     style.position = "absolute"
+    style.display = "block"
+    width = innerWidth - 2*margin;
+    height = innerHeight - 2*margin;
+    style.margin = margin + "px";
 
-    while (1) {
-      left = innerWidth - el.offsetWidth
-      top  = innerHeight - el.offsetHeight
-
-      if (top > 0 && left > 0) break
-
-      style.fontSize = (i -= i * 0.05) + "px"
+    scalex = width/el.offsetWidth
+    scaley = height/el.offsetHeight
+   
+    if (scalex > scaley) {
+      scale = scaley;
+      // Center the content horizontally
+      style.left = (innerWidth - el.offsetWidth*scale)/2 + "px";
+    } else {
+      scale = scalex;
+      // Center the contetent vertically
+      style.top = (innerHeight - el.offsetHeight*scale)/2 + "px";
     }
 
-    style.display = "block"
-    style.top     = top / 2 + "px"
-    style.left    = left / 2 + "px"
+    style["transform-origin"] = "0 0"
+    style.transform = `scale(${scale})`
+
   }
 
   for (var el, count = 0; el = body.firstChild;) {


### PR DESCRIPTION
Hi there

For a presentation I used your weenote script but I wanted to use images and svg elements on the slide. Since your `fir`-function only scale the text size this didn't work for me. So I rewrote the fit function to use css transforms to fit the slide into the browser window.

This has IMHO two advantages:

* It scales whathever element you want to use in a slide, no only text.
* If you use something which isn't text in the fit function, it doesn't result in a infinite loop because the font size doesn't affect the element.

Feel free to ignore my PR, I just thought I'll let you know in case you like my changes. I'm also quite sure that it has downsides that I'm not aware of - even though it worked for my presentation.

Regards

Beni